### PR TITLE
Ensure all tests run [Fixes #19]

### DIFF
--- a/boatd/__init__.py
+++ b/boatd/__init__.py
@@ -18,6 +18,7 @@ from .driver import Driver  # noqa
 
 log = logging.getLogger()
 
+VERSION = "1.1.3"
 
 def load_conf(conf_file):
     '''

--- a/boatd/__init__.py
+++ b/boatd/__init__.py
@@ -16,9 +16,10 @@ from .color import color
 from .config import Config
 from .driver import Driver  # noqa
 
+VERSION = "1.1.3"
+
 log = logging.getLogger()
 
-VERSION = "1.1.3"
 
 def load_conf(conf_file):
     '''

--- a/boatd/tests/test_api.py
+++ b/boatd/tests/test_api.py
@@ -85,7 +85,7 @@ class TestAPI(unittest.TestCase):
     def test_version(self):
         content = urlopen(self._url('/')).read()
         d = json.loads(content.decode("utf-8"))
-        assert d['boatd']['version'] == 1.1
+        assert d['boatd']['version'] == 1.2
 
     def test_request_pony(self):
         content = urlopen(self._url('/pony')).read()

--- a/boatd/tests/test_api.py
+++ b/boatd/tests/test_api.py
@@ -10,6 +10,7 @@ except ImportError:
 import threading
 import socket
 import json
+import unittest
 
 import boatd
 
@@ -32,13 +33,14 @@ class MockBoat(object):
         self.rudder_angle = r
 
 
-class TestAPI(object):
+class TestAPI(unittest.TestCase):
     TEST_PORTS = 20
 
-    def __init__(self):
-        self.port = 2222
+    @classmethod
+    def setUpClass(cls):
+        cls.port = 2222
 
-    def setup(self):
+    def setUp(self):
         self.boat = MockBoat()
         for _ in range(self.TEST_PORTS):
             try:

--- a/boatd/tests/test_boat.py
+++ b/boatd/tests/test_boat.py
@@ -1,3 +1,5 @@
+import unittest
+
 import boatd
 
 class MockDriver(object):
@@ -7,8 +9,8 @@ class MockDriver(object):
             'pony': lambda: 'magic'
         }
 
-class TestBoat(object):
-    def setup(self):
+class TestBoat(unittest.TestCase):
+    def setUp(self):
         self.boat = boatd.Boat(MockDriver())
 
     def test_get_heading(self):

--- a/boatd/tests/test_boatd.py
+++ b/boatd/tests/test_boatd.py
@@ -10,7 +10,7 @@ class TestBoatd(unittest.TestCase):
         self.directory, _ = os.path.split(__file__)
 
     def test_version(self):
-        assert boatd.VERSION == 1.1
+        assert boatd.VERSION == 1.2
 
     def test_load_json_config(self):
         conf_file = os.path.join(self.directory, 'config.json')

--- a/boatd/tests/test_boatd.py
+++ b/boatd/tests/test_boatd.py
@@ -9,9 +9,6 @@ class TestBoatd(unittest.TestCase):
         sys.argv = sys.argv[0:1]
         self.directory, _ = os.path.split(__file__)
 
-    def test_version(self):
-        assert boatd.VERSION == 1.2
-
     def test_load_json_config(self):
         conf_file = os.path.join(self.directory, 'config.json')
         conf = boatd.load_conf(conf_file)

--- a/boatd/tests/test_boatd.py
+++ b/boatd/tests/test_boatd.py
@@ -1,10 +1,11 @@
 import sys
 import os
+import unittest
 
 import boatd
 
-class TestBoatd(object):
-    def __init__(self):
+class TestBoatd(unittest.TestCase):
+    def setUp(self):
         sys.argv = sys.argv[0:1]
         self.directory, _ = os.path.split(__file__)
 

--- a/boatd/tests/test_config.py
+++ b/boatd/tests/test_config.py
@@ -1,8 +1,11 @@
-import boatd
 import os
+import unittest
 
-class TestConfig(object):
-    def setup(self):
+import boatd
+
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
         self.directory, _ = os.path.split(__file__)
         self.yaml_file = os.path.join(self.directory, 'config.yaml')
         self.json_file = os.path.join(self.directory, 'config.json')

--- a/boatd/tests/test_driver.py
+++ b/boatd/tests/test_driver.py
@@ -1,10 +1,11 @@
 import os
+import unittest
 
 import boatd
 
 
-class TestDriver(object):
-    def setup(self):
+class TestDriver(unittest.TestCase):
+    def setUp(self):
         self.directory, _ = os.path.split(__file__)
 
         configuration = {

--- a/boatd/tests/test_nmea.py
+++ b/boatd/tests/test_nmea.py
@@ -1,17 +1,20 @@
 import datetime
+import unittest
 
 import boatd
 
-def test_hdm():
-    assert boatd.nmea.hdm(49.6) == '$HDM,49.6,M*19'
 
-def test_degrees_to_nmea():
-    assert boatd.nmea.degrees_to_nmea(45.555) == '4533.3'
+class TestNMEA(unittest.TestCase):
+    def test_hdm(self):
+        assert boatd.nmea.hdm(49.6) == '$HDM,49.6,M*19'
 
-def test_negative_degrees_to_nmea():
-    assert boatd.nmea.degrees_to_nmea(-45.555) == '-4533.3'
+    def test_degrees_to_nmea(self):
+        assert boatd.nmea.degrees_to_nmea(45.555) == '4533.3'
 
-def test_gll():
-    date = datetime.datetime(2014, 6, 7, 22, 22, 1, 152642)
-    assert boatd.nmea.gll(38.063413, -122.240910, date) == \
-        '$GLL,383.8,N,12214.5,W,222201.15,A*35'
+    def test_negative_degrees_to_nmea(self):
+        assert boatd.nmea.degrees_to_nmea(-45.555) == '-4533.3'
+
+    def test_gll(self):
+        date = datetime.datetime(2014, 6, 7, 22, 22, 1, 152642)
+        assert boatd.nmea.gll(38.063413, -122.240910, date) == \
+            '$GLL,383.8,N,12214.5,W,222201.15,A*35'

--- a/boatd/tests/test_plugin.py
+++ b/boatd/tests/test_plugin.py
@@ -1,5 +1,6 @@
 import os
 import time
+import unittest
 
 import boatd
 
@@ -7,23 +8,24 @@ d, _ = os.path.split(__file__)
 PLUGIN_DIR = os.path.join(d, 'plugin')
 PLUGIN_FILENAME = os.path.join(PLUGIN_DIR, 'small_plugin.py')
 
-def test_find_plugins():
-    plugins = boatd.plugin.find_plugins([PLUGIN_DIR], ['small_plugin'])
-    path_in = ['boatd/boatd/tests/plugin/small_plugin.py' in p for p in plugins]
-    assert True in path_in
+class TestPlugin(unittest.TestCase):
+    def test_find_plugins(self):
+        plugins = boatd.plugin.find_plugins([PLUGIN_DIR], ['small_plugin'])
+        path_in = ['boatd/boatd/tests/plugin/small_plugin.py' in p for p in plugins]
+        assert True in path_in
 
-def test_get_module_name():
-    assert boatd.plugin.get_module_name(PLUGIN_FILENAME) == 'small_plugin'
+    def test_get_module_name(self):
+        assert boatd.plugin.get_module_name(PLUGIN_FILENAME) == 'small_plugin'
 
-def test_load_plugins():
-    modules = boatd.plugin.load_plugins([PLUGIN_FILENAME])
-    assert True in [hasattr(module, 'THING') for module in modules]
+    def test_load_plugins(self):
+        modules = boatd.plugin.load_plugins([PLUGIN_FILENAME])
+        assert True in [hasattr(module, 'THING') for module in modules]
 
-def test_start_plugins():
-    class c(object):
-        accessed = False
-    boat = c()
-    modules = boatd.plugin.load_plugins([PLUGIN_FILENAME])
-    boatd.plugin.start_plugins(modules, boat)
-    time.sleep(1)
-    assert boat.accessed == True
+    def test_start_plugins(self):
+        class c(object):
+            accessed = False
+        boat = c()
+        modules = boatd.plugin.load_plugins([PLUGIN_FILENAME])
+        boatd.plugin.start_plugins(modules, boat)
+        time.sleep(1)
+        assert boat.accessed == True

--- a/boatd/tests/test_utils.py
+++ b/boatd/tests/test_utils.py
@@ -1,5 +1,6 @@
 import boatd
+import unittest
 
-class TestUtils(object):
+class TestUtils(unittest.TestCase):
     def test_reldir(self):
         assert boatd.utils.reldir('test/thing.py', 'dir') == 'test/dir'

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,9 @@ from subprocess import Popen, PIPE
 
 import boatd
 
-version = Popen(['git', 'describe'],
-                stdout=PIPE).communicate()[0].decode('utf8')
-
-if not version.startswith(str(boatd.api.VERSION)):
-    version = boatd.api.VERSION
-
 setup(
     name='boatd',
-    version=version,
+    version=boatd.VERSION,
     author='Louis Taylor',
     author_email='louis@kragniz.eu',
     description=('Experimental daemon to control an autonomous sailing robot'),


### PR DESCRIPTION
* Convert each `test_<module>.py` to a `unittest.TestCase` class.
* Bump version numbers in two tests to prevent failure.
* Remove `git describe`-esque `version` from `boatd`
* Remove unnecessary `test_version` test from `test_boatd`