### PR TITLE
Allow no plugins to be loaded

### DIFF
--- a/boatd/config.py
+++ b/boatd/config.py
@@ -25,10 +25,11 @@ class Config(object):
     '''
 
     def __init__(self, d):
-        self.__dict__.update(d)
-        for k, i in self.__dict__.items():
-            if isinstance(i, dict):
-                self.__dict__[k] = Config(i)
+        if d:
+            self.__dict__.update(d)
+            for k, i in self.__dict__.items():
+                if isinstance(i, dict):
+                    self.__dict__[k] = Config(i)
 
     def __str__(self):
         return str(self.__dict__)


### PR DESCRIPTION
If all plugins were set to `disabled: true`, boatd refused to play
nicely. This commit checks there are actually plugins to before
attempting to load their configurations, to avoid a
"'NoneType' object is not iterable" type error.