### PR TITLE
Remove redundant JSON methods

### DIFF
--- a/boatd/__init__.py
+++ b/boatd/__init__.py
@@ -30,12 +30,7 @@ def load_conf(conf_file):
     otherwise falls back to 'boatd-config.yaml'.
     '''
 
-    _, ext = os.path.splitext(conf_file)
-    if ext == '.json':
-        conf = Config.from_json(conf_file)
-    else:
-        conf = Config.from_yaml(conf_file)
-
+    conf = Config.from_yaml(conf_file)
     conf.filename = conf_file
 
     return conf

--- a/boatd/config.py
+++ b/boatd/config.py
@@ -1,4 +1,4 @@
-import json
+import yaml
 
 
 class Config(object):
@@ -41,15 +41,8 @@ class Config(object):
             return default
 
     @classmethod
-    def from_json(cls, filename):
-        '''Return a Config object from a json file'''
-        with open(filename) as f:
-            return cls(json.load(f))
-
-    @classmethod
     def from_yaml(cls, filename):
         '''Return a Config object from a yaml file'''
-        import yaml
         with open(filename) as f:
             return cls(yaml.load(f))
 

--- a/boatd/tests/test_boatd.py
+++ b/boatd/tests/test_boatd.py
@@ -9,11 +9,6 @@ class TestBoatd(unittest.TestCase):
         sys.argv = sys.argv[0:1]
         self.directory, _ = os.path.split(__file__)
 
-    def test_load_json_config(self):
-        conf_file = os.path.join(self.directory, 'config.json')
-        conf = boatd.load_conf(conf_file)
-        assert conf.scripts.driver == 'driver.py'
-
     def test_load_yaml_config(self):
         conf_file = os.path.join(self.directory, 'config.yaml')
         conf = boatd.load_conf(conf_file)

--- a/boatd/tests/test_config.py
+++ b/boatd/tests/test_config.py
@@ -15,7 +15,7 @@ class TestConfig(unittest.TestCase):
         assert config.boatd
 
     def test_load_json(self):
-        config = boatd.Config.from_json(self.json_file)
+        config = boatd.Config.from_yaml(self.json_file)
         assert config.boatd
 
     def test_port(self):


### PR DESCRIPTION
As JSON is a subset of YAML, we can use the functions for loading
configuration options stored as YAML to also load options stored
as JSON. This means we can simply remove the JSON functions,
simplifying the codebase and excising a slightly suspect file
extension check.
