### PR TITLE
Script for creating boatd waypoints files from GPX

### DIFF
--- a/utils/gpx2waypoints.sh
+++ b/utils/gpx2waypoints.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ "$#" != "1" ] ; then
+  echo "Usage: gpx2waypoints.sh <gpxfile>"
+  echo "Where <gpxfile> is a GPX file created using OpenCPN's route export function and containing rtept points"
+  exit 1
+fi
+
+#look for lines like
+#<rtept lat="52.417712434" lon="-4.095229239">
+#grab the numbers in the quotes and remove duplicate lines as opencpn has a habit of duplicating the last point
+grep "rtept lat" $1 | awk -F\" '{print $2" "$4}' | uniq


### PR DESCRIPTION
OpenCPN can only export waypoints in GPX, this script will convert those files to boatd waypoint files.